### PR TITLE
update account details spec to match updated button text

### DIFF
--- a/src/app/features/account/components/account-details/account-details.component.spec.ts
+++ b/src/app/features/account/components/account-details/account-details.component.spec.ts
@@ -88,7 +88,7 @@ describe('AccountDetailsComponent', () => {
     fixture.detectChanges();
 
     const backButton = fixture.debugElement.query(By.css('button[routerLink="/accounts"]'));
-    expect(backButton.nativeElement.textContent).toContain('Back to Dashboard');
+    expect(backButton.nativeElement.textContent).toContain('Dashboard');
 
     backButton.nativeElement.click();
 


### PR DESCRIPTION
Updated the test expectation to align with the updated button text, replacing "Back to Dashboard" with "Dashboard". This fixes test failures caused by the recent text change in the template.